### PR TITLE
Add support for the audits v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This modular input depends on a couple of npm modules:
 
 ### 2.0.0
  - Use new audits API for more efficient audits retrieval
- - Retrive all audits since the last retrieved audit and now, instead of
+ - Retrieve all audits since the last retrieved audit and now, instead of
    just 100 at a time.
 
 ### 1.0.5

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This modular input uses and requires NodeJS versions 4.0.0 or greater. Please vi
     * `polling_interval`: How often events should be imported in seconds. Defaults to 60 seconds.
     * `client_key`: The key id for your API key.
     * `client_secret`: The secret key for your API key.
-    * `checkpoint_dir`: The directory to store any checkpoint data for the app. This can be anything, but `$SPLUNK_DB/modinputs/` will let splunk manage the data.
+    * `checkpoint_dir`: The directory to store any checkpoint data for the app. This should be a path on persistent storage that Splunk can read and write from.
 8. Enjoy!
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ This modular input depends on a couple of npm modules:
   1. [request](https://www.npmjs.com/package/request) - [Apache 2.0](http://spdx.org/licenses/Apache-2.0)
   2. [async](https://www.npmjs.com/package/async) - [MIT](http://spdx.org/licenses/MIT)
   3. [splunk-sdk](https://www.npmjs.com/package/splunk-sdk) - [Apache 2.0](http://spdx.org/licenses/Apache-2.0)
+  4. [parse-link-header](https://github.com/thlorenz/parse-link-header) - [MIT](http://spdx.org/licenses/MIT)
 
 # Whats New
+
+### 2.0.0
+ - Use new audits API for more efficient audits retrieval
+ - Retrive all audits since the last retrieved audit and now, instead of
+   just 100 at a time.
 
 ### 1.0.5
  - Fix bug that caused the most recent audit event to be duplicated in splunk

--- a/bin/app/sft-audit-events.js
+++ b/bin/app/sft-audit-events.js
@@ -171,7 +171,7 @@
       }]
     }, function(err, results) {
       if (err) {
-              Logger.error(INPUT_NAME, 'Error retrieving audit events: ' + err);
+        Logger.error(INPUT_NAME, 'Error retrieving audit events: ' + err);
         callback(err);
         return;
       }

--- a/bin/app/sft-audit-events.js
+++ b/bin/app/sft-audit-events.js
@@ -155,7 +155,7 @@
 
             audits.list = audits.list.concat(body.list);
             Object.keys(body.related_objects).forEach(function(ro) {
-              audits.relatedObjects[ro.id] = body.related_objects[ro];
+              audits.relatedObjects[ro] = body.related_objects[ro];
             });
 
             callback(null);

--- a/bin/app/sft-audit-events.js
+++ b/bin/app/sft-audit-events.js
@@ -301,7 +301,7 @@
       new Argument({
         name: "checkpoint_dir",
         dataType: Argument.dataTypeString,
-        description: "The path to a directory to hold modular input state. Typically $SPLUNK_DB/modinputs/",
+        description: "The path to a directory to hold modular input state. This should be persistent storage that Splunk can read and write from.",
         requiredOnCreate: true,
         requiredOnEdit: true
       })
@@ -379,7 +379,7 @@
         emitToSplunk: ['getEvents', function (results, callback) {
           var evts = results.getEvents.list,
               relatedObjects = results.getEvents.relatedObjects,
-              indexOffset = "";
+              indexOffset;
 
           if (!evts) {
             callback();

--- a/default/app.conf
+++ b/default/app.conf
@@ -1,6 +1,6 @@
 [install]
 is_configured = 0
-build = 3
+build = 1
 
 [ui]
 is_visible = 0
@@ -10,7 +10,7 @@ attribution_link = https://www.scaleft.com
 [launcher]
 author=scaleft
 description=A modular input that polls the ScaleFT API for audit events and indexes them.
-version = 1.0.2
+version = 2.0.0
 
 [package]
 id = sft-audit-events-splunk


### PR DESCRIPTION
## What
This updates the plugin to use the audits v2 API. This API provides details about the objects(users, projects, clients, etc) to provide more information about the audit.

## How
Updates the format function to properly handle related objects and output them to Splunk.

## Screenshots
![screen shot 2018-09-21 at 12 35 30 am](https://user-images.githubusercontent.com/41267150/45866629-4cd96780-bd36-11e8-9bec-64e42dedbb86.png)
