### PR TITLE
Drop old log lines causing crasher

### DIFF
--- a/bin/app/sft-audit-events.js
+++ b/bin/app/sft-audit-events.js
@@ -212,9 +212,7 @@
         return;
       }
 
-      Logger.info(INPUT_NAME, "Got events: " + results.getAndEmitEvents.list.length);
-
-      callback(null, results.getAndEmitEvents);
+      callback();
     });
   };
 


### PR DESCRIPTION
In #4 we switched the emitter to stream events as they are pulled from the API. In previous versions we'd collect all of the audits, and then emit them. These logs lines cause a crash, and should have been removed previously. 